### PR TITLE
MembershipProvider RefreshPassword fails to save new password to DB

### DIFF
--- a/MongoDB.Web/Providers/MongoDBMembershipProvider.cs
+++ b/MongoDB.Web/Providers/MongoDBMembershipProvider.cs
@@ -367,6 +367,7 @@ namespace MongoDB.Web.Providers
 
             var password = Membership.GeneratePassword(this.MinRequiredPasswordLength, this.MinRequiredNonAlphanumericCharacters);
             var update = Update.Set("LastPasswordChangedDate", DateTime.UtcNow).Set("Password", this.EncodePassword(password, this.PasswordFormat, bsonDocument["Salt"].AsString));
+            this.mongoCollection.Update(query, update);
 
             return password;
         }


### PR DESCRIPTION
The ResetPassword method within the MongoDBMembershipProvider class fails to call             this.mongoCollection.Update(query, update), so the new password is never saved.
